### PR TITLE
Un-define CATCH_CONFIG_CPP11_NULLPTR in include/Tests/catch.hpp to av…

### DIFF
--- a/include/Tests/catch.hpp
+++ b/include/Tests/catch.hpp
@@ -846,6 +846,7 @@ namespace Catch {
 #endif
 
 #include <cstddef>
+#undef CATCH_CONFIG_CPP11_NULLPTR
 
 namespace Catch {
 namespace Internal {


### PR DESCRIPTION
…oid compiler errors in gcc5 that complain about nullptr_t. This appears to have been added with #ifdef protection using this symbol. Not sure if it is really required by us since it compiles fine on both systems with in un-def'd.
