### PR TITLE
model.py: Fix bug in gen_flatten_data()

### DIFF
--- a/python/ccdb/model.py
+++ b/python/ccdb/model.py
@@ -431,7 +431,7 @@ def gen_flatten_data(data):
     """
     #python 3 hack to basestr
     try:
-        unicode = unicode
+        u = unicode
     except NameError:
         # 'unicode' is undefined, must be Python 3
         check_type = str


### PR DESCRIPTION
The "python-3 hack" in this function does not work as intended.
"unicode = unicode" line in try branch results in a "UnboundLocalError"
on both python 2 and 3. This exception is a subclass of NameError, so
the except branch is always taken.

Consequence:
If the data is a very large string (like GlueX translation table),
doing "list(gen_flatten_data(data))" results in:
RuntimeError: maximum recursion depth exceeded in cmp

Recent GlueX translation table updates have been carried out
with ccdb 1.06.00, which does not have this bug.
