### PR TITLE
Feature/better logging

### DIFF
--- a/python/ccdb/cmd/utils/log.py
+++ b/python/ccdb/cmd/utils/log.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from sqlalchemy import desc
 
 import ccdb
 from ccdb import TextFileDOM
@@ -9,7 +10,6 @@ from ccdb.model import LogRecord
 from ccdb import BraceMessage as LogFmt
 
 log = logging.getLogger("ccdb.cmd.utils.log")
-
 
 #ccdbcmd module interface
 def create_util_instance():
@@ -51,39 +51,64 @@ class ShowLog(ConsoleUtilBase):
         provider = self.context.provider
         assert isinstance(provider, AlchemyProvider)
 
-        offset = 0
-        limit = 10
+        result = self.process_arguments(args)
+        log_records = self.filter(result)
 
-        if len(args) == 1:
-            limit = int(args[0])
-        if len(args) == 2:
-            offset = int(args[1])
+        if len(log_records) == 0:
+            print("No entries matching the filter criteria.")
+        else:
+            self.print_logs(log_records)
 
-        log_records = provider.get_log_records(limit=limit, offset=offset)
+    def process_arguments(self, args):
+        # utility argument parser is argparse which raises errors instead of exiting app
+        parser = UtilityArgumentParser()
+        parser.add_argument("obj_name", nargs="?", default="")
+        parser.add_argument("-t", "--table", default="")
+        parser.add_argument("-v", "--variation", default="")
+        parser.add_argument("-u", "--user", default="")
+        parser.add_argument("-d", "--date", default="") # TODO: Implement filter by date
+        result = parser.parse_args(args)
+        return result
 
-        if not log_records:
-            print ("No log records found")
-            return 0
+# ----------------------------------------
+#   filtering
+# ----------------------------------------
+    def filter(self, result):
+
+        query = self.context.provider.session.query(LogRecord)
+
+        if result.user: # filter by user
+            user_id = self.context.provider.get_user(result.user).id
+            query = query.filter(LogRecord.author_id.like("{0}".format(user_id)))
+
+        if result.table or result.obj_name: # filter by table
+
+            user_input = result.obj_name if result.obj_name else result.table
+
+            user_input = user_input.replace("_", "\\_").replace("*", "%").replace("?", "_")
+            full_table_path = self.context.prepare_path(user_input)
+            query = query.filter(LogRecord.description.like("%'{0}%:%:%:%".format(full_table_path)))
+
+        if result.variation: # filter by variation
+            query = query.filter(LogRecord.description.like("%:%:{0}:%".format(result.variation)))
+
+        query.order_by(desc(LogRecord.id))
+
+        return query.all()
+
+
+#----------------------------------------
+#   print logs
+#----------------------------------------
+    def print_logs(self, log_records):
 
         print self.theme.Directories + "(action)        (author)         (date)                 (description)"
 
         for log_record in log_records:
-            assert isinstance(log_record, LogRecord)
             print " %-13s "%log_record.action +\
-                  " %-16s"%log_record.author.name + \
-                  " %-18s"%log_record.created.strftime("%Y-%m-%d %H-%M-%S   ") + " " +\
-                  log_record.description
-
-    def process_arguments(args):
-        # utility argument parser is argparse which raises errors instead of exiting app
-        parser = UtilityArgumentParser()
-        parser.add_argument("raw_path", nargs='?', default="")
-        parser.add_argument("-x", "--dtree", action="store_true")
-        parser.add_argument("-d", "--directories", action="store_true")
-        parser.add_argument("-t", "--tables", action="store_true")
-        parser.add_argument("-v", "--variations", action="store_true")
-        parser.add_argument("-l", "--extended", action="store_true")
-
+                " %-16s"%log_record.author.name + \
+                " %-18s"%log_record.created.strftime("%Y-%m-%d %H-%M-%S   ") + " " +\
+                 log_record.description
 
 
 #----------------------------------------

--- a/python/ccdb/path_utils.py
+++ b/python/ccdb/path_utils.py
@@ -67,7 +67,7 @@ def join(a, *p):
 
 
 #______________________________________________________________________________
-def parse_time(timeStr="-1"):
+def parse_time(timeStr="-1", max_time_by_default=True):
     """ @brief ParseTime
     parses time as any part of
     YYYY:MM:DD-hh:mm:ss
@@ -88,12 +88,20 @@ def parse_time(timeStr="-1"):
     #the function is ported from C++ dont be surprise by struct_time
     
     #default result
-    year=2037
-    month = 12
-    day = 31
-    hour = 23
-    minute = 59
-    second = 59
+    if max_time_by_default:
+        year=2037
+        month = 12
+        day = 31
+        hour = 23
+        minute = 59
+        second = 59
+    else:
+        year = 2000
+        month = 1
+        day = 1
+        hour = 0
+        minute = 0
+        second = 0
 
     #some tmp values
     tmpStr =""     #tmp string to buffer chars

--- a/python/ccdb/provider.py
+++ b/python/ccdb/provider.py
@@ -1547,5 +1547,3 @@ class AlchemyProvider(object):
 
         # execute and return
         return query.all()
-
-

--- a/python/tests/test_console_context.py
+++ b/python/tests/test_console_context.py
@@ -58,6 +58,13 @@ class ConsoleContextTests(unittest.TestCase):
         logger.addHandler(ch)
         logger.setLevel(logging.INFO)
 
+        self.context.provider.connect(self.context.connection_string)
+        user = self.context.provider.get_current_user()
+        # create some test logs w/ current user
+        self.context.provider.create_log_record(user, ["1"], "create",
+                                                "Created assignment '/testing_filter/start_parms:0:testing_filter:2013-01-17_19-02-27'",
+                                                "Test Log" )
+
     def tearDown(self):
         # restore stdout
         sys.stdout = self.saved_stdout
@@ -254,3 +261,30 @@ class ConsoleContextTests(unittest.TestCase):
     def test_list_current_user(self):
         self.context.process_command_line("user")
         self.assertIn('test_user', self.output.getvalue())
+
+    def test_filter_logs_by_username(self):
+
+        self.context.process_command_line("log -u test_user")
+        # we should see this in the logs
+        self.assertIn("test_user", self.output.getvalue())
+
+    def test_filter_logs_by_table(self):
+
+        self.context.process_command_line("log -t test")
+        # we should see this in the logs
+        self.assertIn("test", self.output.getvalue())
+
+    def test_filter_logs_by_variation(self):
+
+        self.context.process_command_line("log -v default")
+        # we should see this in the logs
+        self.assertIn("default", self.output.getvalue())
+
+    def test_filter_logs_by_all(self):
+
+        self.context.process_command_line("log -u test_user -v default -t test")
+
+        # we should see these in the logs
+        self.assertIn("default", self.output.getvalue())
+        self.assertIn("test_user", self.output.getvalue())
+        self.assertIn("test", self.output.getvalue())


### PR DESCRIPTION
# Problem 
The `log` command only outputted all the logs recorded, and there was no way to filter them. 


# Solution 
You can now filter logs by the user, table, and variation using -u/--user, -v/--variation, and -t/--table. 