### PR TITLE
Scons python3 config fix

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/SConstruct
+++ b/SConstruct
@@ -3,8 +3,8 @@ import os
 
 #Setup default environment. This environment 
 if not 'CCDB_HOME' in os.environ:
-    print "CCDB_HOME environment variable is not found but should be set to compile the CCDB"
-    print "One can run 'source environment.bash' from your bash shell to automatically set environment variables"
+    print("CCDB_HOME environment variable is not found but should be set to compile the CCDB")
+    print("One can run 'source environment.bash' from your bash shell to automatically set environment variables")
     exit(1)
 
 #Create 'default' environment. Other environments will be a copy of this one

--- a/python/ccdb/__init__.py
+++ b/python/ccdb/__init__.py
@@ -45,7 +45,7 @@ def get_ccdb_home_path():
 
 def init_ccdb_console():
     from .cmd import ConsoleContext
-    import cmd.colorama
+    import ccdb.cmd.colorama
 
     # TODO move ccdb to pure logging. NO print command at all
 

--- a/python/ccdb/cmd/utils/cat.py
+++ b/python/ccdb/cmd/utils/cat.py
@@ -73,6 +73,7 @@ class Cat(ConsoleUtilBase):
         self.show_date = False
         self.request = ParseRequestResult()
         self.ass_id = 0
+        self.use_ass_id = False 
         self.user_request_print_horizontal = False
         self.user_request_print_vertical = False
 

--- a/python/ccdb/cmd/utils/cp.py
+++ b/python/ccdb/cmd/utils/cp.py
@@ -1,0 +1,97 @@
+import posixpath
+import logging
+import os
+
+from ccdb.errors import DirectoryNotFound
+from ccdb.model import Directory, TypeTable
+from ccdb.provider import AlchemyProvider
+from ccdb.cmd import ConsoleUtilBase, UtilityArgumentParser
+from ccdb import BraceMessage as LogFmt
+
+log = logging.getLogger("ccdb.cmd.utils.cp")
+
+# ccdbcmd module interface
+def create_util_instance():
+    log.debug("   copying data")
+
+    return Copy()
+
+#*********************************************************************
+#   Class Info - Copies data to a different assignment               *
+#                                                                    *
+#*********************************************************************
+class Copy(ConsoleUtilBase):
+    """Copies data to a different assignment"""
+
+    # ccdb utility class descr part
+    # ------------------------------
+    command = "cp"
+    name = "Copy"
+    short_descr = "Copies data from one assignment to another assignment"
+    uses_db = True
+
+
+    def process(self, args):
+        """This is an entry point for each time the command is called"""
+
+        if log.isEnabledFor(logging.DEBUG):
+            log.debug(LogFmt("{0}Copy is in charge{0}\\".format(os.linesep)))
+            log.debug(LogFmt(" |- arguments : '" + "' '".join(args)+"'"))
+
+        # get provider class which has functions for all CCDB database operation
+        assert self.context
+        provider = self.context.provider
+        assert isinstance(provider, AlchemyProvider)
+
+        # process arguments
+        parsed_args = self.process_arguments(args)
+
+        if not self.validate(parsed_args):
+            return 1   # the return is like application ret. 1 means problems
+
+        path = self.context.prepare_path(parsed_args.raw_path)   # add current path to user input
+
+        # try avoid print() and use log to print data
+        log.info(LogFmt("{0}raw_path{1} : {2}", self.theme.Accent, self.theme.Reset, parsed_args.raw_path))
+        log.info(LogFmt("{0}path{1}     : {2}", self.theme.Accent, self.theme.Reset, path))
+        log.info(LogFmt("{0}variation{1}: {2}", self.theme.Accent, self.theme.Reset, parsed_args.variation))
+        log.info(LogFmt("{0}run{1}      : {2}", self.theme.Accent, self.theme.Reset, parsed_args.run))
+
+        # the return is like application ret. 0 means OK
+        return 0
+
+    # ----------------------------------------
+    #   process_arguments
+    # ----------------------------------------
+    def process_arguments(self, args):
+        # solo arguments
+
+        # utility argument parser is argparse which raises errors instead of exiting app
+        parser = UtilityArgumentParser()
+        parser.add_argument("raw_path")
+        parser.add_argument("-v", "--variation", default=self.context.current_variation)
+        parser.add_argument("-r", "--run", default=self.context.current_run, type=int)
+
+        return parser.parse_args(args)
+
+    # ----------------------------------------
+    #   validate
+    # ----------------------------------------
+    def validate(self, parsed_args):
+        if not ccdb.path_utils.validate_name(parsed_args.raw_path):
+            log.error("The wrong path is given")
+            return False
+
+        return True
+
+    # ----------------------------------------
+    #   print_help
+    # ----------------------------------------
+    def print_help(self):
+        """Prints help for the command"""
+
+        print("""This is empty utility. It is a template and a sample for writing new utilities
+
+    """)
+
+

--- a/python/ccdb/cmd/utils/empty.py
+++ b/python/ccdb/cmd/utils/empty.py
@@ -90,15 +90,15 @@ class Empty(ConsoleUtilBase):
             log.debug(LogFmt("{0}Empty is in charge{0}\\".format(os.linesep)))
             log.debug(LogFmt(" |- arguments : '" + "' '".join(args)+"'"))
 
-        #prepare variables for the new command
+        # prepare variables for the new command
         self.__cleanup()
 
-        #get provider class which has functions for all CCDB database operation
+        # get provider class which has functions for all CCDB database operation
         assert self.context
         provider = self.context.provider
         assert isinstance(provider, AlchemyProvider)
 
-        #process arguments
+        # process arguments
         parsed_args = self.process_arguments(args)
 
         if not self.validate(parsed_args):
@@ -115,9 +115,9 @@ class Empty(ConsoleUtilBase):
         # the return is like application ret. 0 means OK
         return 0
 
-#----------------------------------------
+# ----------------------------------------
 #   process_arguments 
-#----------------------------------------  
+# ----------------------------------------
     def process_arguments(self, args):
         #solo arguments
 
@@ -129,9 +129,9 @@ class Empty(ConsoleUtilBase):
 
         return parser.parse_args(args)
 
-#----------------------------------------
+# ----------------------------------------
 #   validate 
-#----------------------------------------  
+# ----------------------------------------
     def validate(self, parsed_args):
         if not ccdb.path_utils.validate_name(parsed_args.raw_path):
             log.error("The wrong path is given")
@@ -139,9 +139,9 @@ class Empty(ConsoleUtilBase):
 
         return True
 
-#----------------------------------------
+# ----------------------------------------
 #   print_help 
-#----------------------------------------
+# ----------------------------------------
     def print_help(self):
         """Prints help for the command"""
         

--- a/python/ccdb/cmd/utils/info.py
+++ b/python/ccdb/cmd/utils/info.py
@@ -103,20 +103,20 @@ class Info(ConsoleUtilBase):
     # ----------------------------------------
     def print_directory(self, directory):
         assert isinstance(directory, Directory)
-        print " Name      :  " + self.theme.Success + directory.name
-        print " Full path :  " + directory.path
+        print (" Name      :  " + self.theme.Success + directory.name)
+        print (" Full path :  " + directory.path)
         try:
-            print " Created   :  " + directory.created.strftime("%Y-%m-%d %H-%M-%S")
+            print (" Created   :  " + directory.created.strftime("%Y-%m-%d %H-%M-%S"))
         except Exception as ex:
             log.warning("Directory created time getting error: " + str(ex))
         try:
-            print " Modified  :  " + directory.modified.strftime("%Y-%m-%d %H-%M-%S")
+            print (" Modified  :  " + directory.modified.strftime("%Y-%m-%d %H-%M-%S"))
         except Exception as ex:
             log.warning("Directory modify time getting error: " + str(ex))
 
         #comment
-        print " Comment: "
-        print directory.comment
+        print (" Comment: ")
+        print (directory.comment)
         print
 
     #----------------------------------------
@@ -125,33 +125,32 @@ class Info(ConsoleUtilBase):
     def print_type_table(self, table):
         #basic values: name rows columns path
         assert isinstance(table, TypeTable)
-        print "+------------------------------------------+"
-        print "| Type table information                   |"
-        print "+------------------------------------------+"
-        print " Name       :  " + self.theme.Success + table.name
-        print " Full path  :  " + table.path
-        print " Rows       :  " + self.theme.Accent + repr(int(table.rows_count))
-        print " Columns    :  " + self.theme.Accent + repr(int(table.columns_count))
-        print " Created    :  " + table.created.strftime("%Y-%m-%d %H-%M-%S")
-        print " Modified   :  " + table.modified.strftime("%Y-%m-%d %H-%M-%S")
-        print " DB Id      :  " + repr(int(table.id))
-        print "+------------------------------------------+"
-        print "| Columns info                             |"
-        print "+------------------------------------------+"
+        print ("+------------------------------------------+")
+        print ("| Type table information                   |")
+        print ("+------------------------------------------+")
+        print (" Name       :  " + self.theme.Success + table.name)
+        print (" Full path  :  " + table.path)
+        print (" Rows       :  " + self.theme.Accent + repr(int(table.rows_count)))
+        print (" Columns    :  " + self.theme.Accent + repr(int(table.columns_count)))
+        print (" Created    :  " + table.created.strftime("%Y-%m-%d %H-%M-%S"))
+        print (" Modified   :  " + table.modified.strftime("%Y-%m-%d %H-%M-%S"))
+        print (" DB Id      :  " + repr(int(table.id)))
+        print ("+------------------------------------------+")
+        print ("| Columns info                             |")
+        print ("+------------------------------------------+")
         #columns info 
         print
-        print "Columns info "
-        print " N.   (type)    : (name)"
+        print ("Columns info ")
+        print (" N.   (type)    : (name)")
         for column in table.columns:
-            print " " + repr(int(column.order)).ljust(4) \
-                  + " " + self.theme.Type + "%-10s" % column.type + self.theme.Reset + ": " + column.name
+            print (" " + repr(int(column.order)).ljust(4) + " " + self.theme.Type + "%-10s" % column.type + self.theme.Reset + ": " + column.name)
 
-        print
-        print "+------------------------------------------+"
+        print('')
+        print("+------------------------------------------+")
         #comment
-        print "Comment: "
-        print table.comment
-        print
+        print ("Comment: ")
+        print (table.comment)
+        print()
 
     #----------------------------------------
     #   print_variation
@@ -159,16 +158,16 @@ class Info(ConsoleUtilBase):
     def print_variation(self, variation):
         #basic values: name rows columns path
         assert isinstance(variation, Variation)
-        print "+------------------------------------------+"
-        print "| Variation information                    |"
-        print "+------------------------------------------+"
-        print " Name       :  " + self.theme.Success + variation.name
-        print " Created    :  " + variation.created.strftime("%Y-%m-%d %H-%M-%S")
-        print " DB Id      :  " + repr(int(variation.id))
-        print " Parent     :  " + (variation.parent.name if variation.parent else "--")
-        print " Comment:  "
-        print variation.comment
-        print
+        print ("+------------------------------------------+")
+        print ("| Variation information                    |")
+        print ("+------------------------------------------+")
+        print (" Name       :  " + self.theme.Success + variation.name)
+        print (" Created    :  " + variation.created.strftime("%Y-%m-%d %H-%M-%S"))
+        print (" DB Id      :  " + repr(int(variation.id)))
+        print (" Parent     :  " + (variation.parent.name if variation.parent else "--"))
+        print (" Comment:  ")
+        print (variation.comment)
+        print()
 
     #----------------------------------------
     #   print_help
@@ -176,13 +175,13 @@ class Info(ConsoleUtilBase):
     def print_help(self):
         """Prints help of the command"""
 
-        print """Prints extended info about the object
+        print ("""Prints extended info about the object
     info <type table path>   - info about type table with given path
     info -d <directory path> - info about directory with given path
     info -v <variation name> - info about variation with given name
     info -f <file name>      - info about text file (col. names), rows, etc.
     
-    """
+    """)
 
     def print_file(self, file_path):
         #reading file

--- a/python/ccdb/cmd/utils/log.py
+++ b/python/ccdb/cmd/utils/log.py
@@ -102,13 +102,13 @@ class ShowLog(ConsoleUtilBase):
 #----------------------------------------
     def print_logs(self, log_records):
 
-        print self.theme.Directories + "(action)        (author)         (date)                 (description)"
+        print (self.theme.Directories + "(action)        (author)         (date)                 (description)")
 
         for log_record in log_records:
-            print " %-13s "%log_record.action +\
+            print (" %-13s "%log_record.action +\
                 " %-16s"%log_record.author.name + \
                 " %-18s"%log_record.created.strftime("%Y-%m-%d %H-%M-%S   ") + " " +\
-                 log_record.description
+                 log_record.description)
 
 
 #----------------------------------------
@@ -117,10 +117,10 @@ class ShowLog(ConsoleUtilBase):
     def print_help(self):
         """Prints help of the command"""
           
-        print """Shows log records
+        print ("""Shows log records
     log <records to show>  <records to skip>
 
 Example:
     > log
     > log 50
-    """
+    """)

--- a/python/ccdb/cmd/utils/ls.py
+++ b/python/ccdb/cmd/utils/ls.py
@@ -239,9 +239,9 @@ class List(ConsoleUtilBase):
 
         #print this directory
         if not printFullPath:
-            print "".join(["   " for i in range(0, level)]) + directory.name
+            print ("".join(["   " for i in range(0, level)]) + directory.name)
         else:
-            print directory.path
+            print (directory.path)
 
         #print subdirectories recursively
         sub_dirs = directory.sub_dirs
@@ -274,7 +274,7 @@ class List(ConsoleUtilBase):
     def print_help(self):
         """Prints help of the command"""
 
-        print """
+        print ("""
 Lists directories and tables for current directory
 
 - Accepts wildcards symbols '*', and '?'
@@ -289,7 +289,7 @@ keys:
     -x or --dtree        - draws directory tree
 
     -l or --extended     - shows extended info when is used on table
-"""
+""")
 
 
 class ListTasks(object):

--- a/python/ccdb/cmd/utils/mktbl.py
+++ b/python/ccdb/cmd/utils/mktbl.py
@@ -135,7 +135,7 @@ class MakeTable(ConsoleUtilBase):
         log.debug("  write table to database...")
         self.context.provider.create_type_table(self.table_name, self.table_parent_path, self.rows, self.columns,
                                                 self.comment)
-        print "saving table to database... " + self.theme.Success + " completed" + self.theme.Reset
+        print ("saving table to database... " + self.theme.Success + " completed" + self.theme.Reset)
 
     #----------------------------------------------
     #   process_arguments - process input arguments
@@ -323,7 +323,7 @@ class MakeTable(ConsoleUtilBase):
     def print_help(self):
         """prints help for MakeTable"""
 
-        print """
+        print ("""
 MakeTable or mktbl - create type table with the specified namepath and parameters
 
 usage: 
@@ -387,67 +387,67 @@ keys:
                                      mktbl -nq ... 10val  - creates 1 column named '10val'
 
     -f <file> or --file <file>  Infer type table from text table file.(Hint: column names row should start with #&)
-            """
+            """)
 
     #----------------------------------------------
     #   print_validation - PRINTS VALIDATION TABLE
     #----------------------------------------------
     def print_validation(self):
         #basic values: name rows columns path
-        print
+        print()
         if not len(self.table_name):
-            print "Table: " + self.theme.Fail + "Name is not set"
+            print ("Table: " + self.theme.Fail + "Name is not set")
         else:
-            print "Table: " + self.theme.Success + self.table_name
+            print ("Table: " + self.theme.Success + self.table_name)
 
-        print "Rows num: " + repr(self.rows) + self.theme.Reset + \
-              "   Columns num: " + repr(len(self.columns))
-        print "Full path: " + self.table_path
+        print ("Rows num: " + repr(self.rows) + self.theme.Reset + \
+               "   Columns num: " + repr(len(self.columns)))
+        print ("Full path: " + self.table_path)
         #columns info 
         print
-        print "Columns: "
-        print "   (type)    : (name)"
+        print ("Columns: ")
+        print ("   (type)    : (name)")
         for (colname, coltype) in self.columns:
-            print "   " + self.theme.Type + "%-10s" % coltype + self.theme.Reset + ": " + colname
+            print ("   " + self.theme.Type + "%-10s" % coltype + self.theme.Reset + ": " + colname)
         print
         #comment
-        print "Comment: "
+        print ("Comment: ")
         if len(self.comment):
-            print self.comment
+            print (self.comment)
         else:
-            print self.theme.Fail + "Comment is empty"
+            print (self.theme.Fail + "Comment is empty")
 
         #additional info print
         print
-        print "Additional info: "
+        print ("Additional info: ")
         if self.rows_set:
-            print "   Rows number is set by " + self.theme.Success + "User"
+            print ("   Rows number is set by " + self.theme.Success + "User")
         else:
-            print "   Rows number is set by " + self.theme.Accent + "Default"
+            print ("   Rows number is set by " + self.theme.Accent + "Default")
 
         if self.comment_set:
-            print "   Comments added by " + self.theme.Success + "User"
+            print ("   Comments added by " + self.theme.Success + "User")
         else:
-            print "   No comments are set"
+            print ("   No comments are set")
 
 
     def print_settings_summary(self):
-        print self.theme.Success + " Summary: "
-        print "  columns: ", self.columns
-        print "  unparsed_columns: ", self.unparsed_columns
-        print
-        print "    rows            : ", self.rows
-        print "    rows_set        : ", repr(self.rows_set)
-        print
-        print "    interactive     : ", repr(self.interactive)
-        print "    interactive_set : ", repr(self.interactive_set)
-        print
-        print "    comment         : ", self.comment
-        print "    comment_set     : ", repr(self.comment_set)
-        print
-        print "    table_name      : ", self.table_name
-        print
-        print "    table_path      : ", self.table_path
-        print "    table_path_set  : ", repr(self.table_path_set)
-        print
-        print "    table_parent_path      : ", self.table_parent_path
+        print (self.theme.Success + " Summary: ")
+        print ("  columns: ", self.columns)
+        print ("  unparsed_columns: ", self.unparsed_columns)
+        print()
+        print ("    rows            : ", self.rows)
+        print ("    rows_set        : ", repr(self.rows_set))
+        print()
+        print ("    interactive     : ", repr(self.interactive))
+        print ("    interactive_set : ", repr(self.interactive_set))
+        print()
+        print ("    comment         : ", self.comment)
+        print ("    comment_set     : ", repr(self.comment_set))
+        print()
+        print ("    table_name      : ", self.table_name)
+        print()
+        print ("    table_path      : ", self.table_path)
+        print ("    table_path_set  : ", repr(self.table_path_set))
+        print()
+        print ("    table_parent_path      : ", self.table_parent_path)

--- a/python/ccdb/cmd/utils/mkvar.py
+++ b/python/ccdb/cmd/utils/mkvar.py
@@ -69,7 +69,7 @@ class MakeVariation(ConsoleUtilBase):
     def print_help(self):
         """prints help to user"""
 
-        print """
+        print ("""
 MakeVariation or mkvar - create variation with specified name
 
 usage:
@@ -80,4 +80,4 @@ usage:
     name           - is a variation name. [a-z A-Z 0-9 _] are allowed symbols
     comments       - are comments... don't forget space before #
     -p or --parent - name of parent variation. If no name provided, "default" variation is the parent
-            """
+            """)

--- a/python/ccdb/cmd/utils/pwd.py
+++ b/python/ccdb/cmd/utils/pwd.py
@@ -24,11 +24,11 @@ class PrintWorkDir(ConsoleUtilBase):
     short_descr = "Prints working directory"
     
     def print_help(self):
-        print """ Prints working directory """ 
+        print (""" Prints working directory """)
 
 
     def process(self, args):
         log.debug("  PrintWorkDir is gained a control over the process.")
         log.debug("    ".join(args))
         assert self.context is not None
-        print self.context.current_path
+        print (self.context.current_path)

--- a/python/ccdb/cmd/utils/rm.py
+++ b/python/ccdb/cmd/utils/rm.py
@@ -149,7 +149,7 @@ class Remove(ConsoleUtilBase):
     def print_warning(self):
         """print warning"""
         
-        print """ 
+        print (""" 
                     (!) WARNING (!) 
           CCDB is no-delete storage by design!
 
@@ -159,7 +159,7 @@ which using this names.
 
 Deleting a table and recreating with different signature could 
 lead to even more severe hard-to-diagnose errors.
-"""
+""")
         
 
 
@@ -169,7 +169,7 @@ lead to even more severe hard-to-diagnose errors.
     def print_help(self):
         """Prints help of the command"""
           
-        print """Removes type table, directory or variation
+        print ("""Removes type table, directory or variation
     rm <type table path>   - removes type table with given path
     rm -d <directory path> - removes directory with given path
     rm -v <variation name> - removes variation with given name
@@ -179,4 +179,4 @@ lead to even more severe hard-to-diagnose errors.
 
    -f or --force - removes object without question
     
-    """
+    """)

--- a/python/ccdb/cmd/utils/run.py
+++ b/python/ccdb/cmd/utils/run.py
@@ -24,7 +24,7 @@ class CurrentRun(ConsoleUtilBase):
     short_descr = "gets or sets current working run"
     
     def print_help(self):
-        print """ gets or sets current working run
+        print (""" gets or sets current working run
         run (with no arguments) will display current working run
         run <run_number> will set current working run to this number
 
@@ -40,7 +40,7 @@ Example:
    > ccdb -r 1000 cat /test/some_constants
 
 If no run specified at ccdb start, current working run is 0
-        """ 
+        """)
     # ---- end of print_help() ----
 
 
@@ -60,7 +60,7 @@ If no run specified at ccdb start, current working run is 0
                 return 1
         else:
             #get working run
-            print self.context.current_run
+            print (self.context.current_run)
         
         # all is fine
         return 0

--- a/python/ccdb/cmd/utils/usage.py
+++ b/python/ccdb/cmd/utils/usage.py
@@ -24,7 +24,7 @@ class Usage(ConsoleUtilBase):
     help_util = True
     
     def print_help(self):
-        print """ Prints the usage of the command """ 
+        print (""" Prints the usage of the command """)
     # ---- end of print_help() ----
 
 

--- a/python/ccdb/cmd/utils/user.py
+++ b/python/ccdb/cmd/utils/user.py
@@ -58,7 +58,7 @@ class User(ConsoleUtilBase):
     def print_help(self):
         """prints help to user"""
 
-        print """
+        print ("""
 User or user - manages users
 
 usage:
@@ -68,4 +68,4 @@ usage:
     user                  - prints the current user of the database.
 
     name           - is the username of the new user. [a-z A-Z 0-9 _] are allowed symbols
-            """
+            """)

--- a/python/ccdb/cmd/utils/var.py
+++ b/python/ccdb/cmd/utils/var.py
@@ -29,7 +29,7 @@ class CurrentVariation(ConsoleUtilBase):
     short_descr = "gets or sets current working variation"
     
     def print_help(self):
-        print """Gets or sets current working variation
+        print ("""Gets or sets current working variation
         var (no arguments)     displays current variation
         var <variation_name>   sets current variation
 
@@ -44,7 +44,7 @@ Current working variation can be set on ccdb start by '-v' flag.
    \\> ccdb -v smith cat /test/some_constants   #set variation at ccdb start
 
 If no variation specified at ccdb start, current working variation is 'default'
-        """
+        """)
     # ---- end of print_help() ----
 
 
@@ -62,7 +62,7 @@ If no variation specified at ccdb start, current working variation is 'default'
             log.info(Lfm("Working variation is set to '{}'", self.context.current_variation))
         else:
             #get working run
-            print self.context.current_variation
+            print (self.context.current_variation)
         
         # all is fine
         return 0

--- a/python/ccdb/cmd/utils/vers.py
+++ b/python/ccdb/cmd/utils/vers.py
@@ -84,24 +84,24 @@ class Versions(ConsoleUtilBase):
             print("For variation: {}".format(variation))
 
         # table header... and table =)
-        print self.theme.Directories + "(ID)   (Created)              (Modified)              (variation)     (run range)      (comments)"
+        print (self.theme.Directories + "(ID)   (Created)              (Modified)              (variation)     (run range)      (comments)")
         for asgmnt in assignments:
             assert isinstance(asgmnt, ccdb.Assignment)
             max_str = repr(asgmnt.run_range.max)
             if asgmnt.run_range.max == ccdb.INFINITE_RUN:
                 max_str="inf"
-            print " %-5i "%asgmnt.id +\
+            print (" %-5i "%asgmnt.id +\
                   " %-20s"%asgmnt.created.strftime("%Y-%m-%d %H-%M-%S   ") +\
                   " %-20s"%asgmnt.modified.strftime("%Y-%m-%d %H-%M-%S   ") + " " +\
                   " %-14s "%asgmnt.variation.name +\
                   " %-15s "%(repr(asgmnt.run_range.min) + "-" + max_str) +\
-                  asgmnt.comment[0:20].replace("\n", " ")
+                  asgmnt.comment[0:20].replace("\n", " "))
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     def print_help(self):
         """Prints help of the command"""
           
-        print """Show versions of data for specified type table
+        print ("""Show versions of data for specified type table
 
 Flags:
     -v or --variation  - filters output by variation
@@ -114,4 +114,4 @@ Example:
     >> vers /test/test_vars/test_table   #get all data versions
     >> cd /test/test_vars                #navigate to directory
     >> vers -v default test_table        #shows only data versions in default variation
-    """
+    """)

--- a/src/Library/SConscript
+++ b/src/Library/SConscript
@@ -118,7 +118,7 @@ if ARGUMENTS.get("mysql","no")=="yes" or ARGUMENTS.get("with-mysql","true")=="tr
     env.Append(LIBS=['mysqlclient'])
     env.ParseConfig('mysql_config --cflags')
 else:
-    print "CCDB is being build WITHOUT MySQL support. Use 'with-mysql=true' flag to explicitly enable MySQL support"
+    print("CCDB is being build WITHOUT MySQL support. Use 'with-mysql=true' flag to explicitly enable MySQL support")
 
 
 if ARGUMENTS.get("with-perflog","false")=="true":

--- a/src/Library/SConscript
+++ b/src/Library/SConscript
@@ -97,7 +97,8 @@ if ARGUMENTS.get("mysql","no")=="yes" or ARGUMENTS.get("with-mysql","true")=="tr
 	
 	lib_sources.extend(mysql_sources)	
 	env.Append(CPPDEFINES='CCDB_MYSQL')
-	env.ParseConfig('mysql_config --libs --cflags')
+	env.Append(LIBS='mysqlclient')
+	env.ParseConfig('mysql_config --cflags')
 else:
 	print "CCDB is being build WITHOUT MySQL support. Use 'with-mysql=true' flag to explicitly enable MySQL support"
 	

--- a/src/Library/SConscript
+++ b/src/Library/SConscript
@@ -8,8 +8,8 @@ env = default_env.Clone()  #Clone it to add library specified things
 
 #Mac Os X requires install_name flag to be built properly
 if env['PLATFORM'] == 'darwin':
-    print
-    print "Darwin platform is detected. Setting -install_name @rpath/"+'${TARGET.file}'
+    print()
+    print("Darwin platform is detected. Setting -install_name @rpath/"+'${TARGET.file}')
     env.Append(SHLINKFLAGS = ['-install_name', '@rpath/'+'${TARGET.file}'])
     
 
@@ -74,21 +74,21 @@ else:
 #Read user flag for using mysql dependencies or not
 if ARGUMENTS.get("mysql","no")=="yes" or ARGUMENTS.get("with-mysql","true")=="true":
     #User wants mysql!
-    print "Building CCDB using MySQL dependencies"
-    print "To build CCDB without mysql dependencies. Run scons with 'with-mysql=false'"
-    print ""
+    print("Building CCDB using MySQL dependencies")
+    print("To build CCDB without mysql dependencies. Run scons with 'with-mysql=false'")
+    print("")
 
     print('WhereIs("mysql_config"): {}'.format(WhereIs("mysql_config")))
 
     mysql_config_path = WhereIs("mysql_config")
 
     if not mysql_config_path:
-        print
-        print 	"ERROR. Can't find 'mysql_config' utility which is needed to build CCDB with MySQL support."
-        print 	"Two options is possible to build CCDB:"
-        print   "  1. Install mysql_config (RHEL has it in mysql-devel package, Ubuntu in libmysqlclient-dev)"
-        print   "  2. Build CCDB without MySQL dependencies (use 'mysql=no' scons flag)"
-        print
+        print()
+        print("ERROR. Can't find 'mysql_config' utility which is needed to build CCDB with MySQL support.")
+        print("Two options is possible to build CCDB:")
+        print("  1. Install mysql_config (RHEL has it in mysql-devel package, Ubuntu in libmysqlclient-dev)")
+        print("  2. Build CCDB without MySQL dependencies (use 'mysql=no' scons flag)")
+        print()
         Exit()
 
     mysql_sources = [

--- a/src/Library/SConscript
+++ b/src/Library/SConscript
@@ -18,49 +18,49 @@ lib_target  = "ccdb"
 lib_sources = [
     
     #some global objects    
-	"Console.cc",
-	"Log.cc",
-	"CCDBError.cc",
-	"GlobalMutex.cc",
-	"IMutex.cc",
-	"ISyncObject.cc",
-	"PthreadMutex.cc",
-	"PthreadSyncObject.cc",
-	
-	#user api
-	"Calibration.cc",
-	"CalibrationGenerator.cc",
+    "Console.cc",
+    "Log.cc",
+    "CCDBError.cc",
+    "GlobalMutex.cc",
+    "IMutex.cc",
+    "ISyncObject.cc",
+    "PthreadMutex.cc",
+    "PthreadSyncObject.cc",
+
+    #user api
+    "Calibration.cc",
+    "CalibrationGenerator.cc",
     "SQLiteCalibration.cc",
-	
-	#helper classes
-	"Helpers/StringUtils.cc",
-	"Helpers/PathUtils.cc",
-	"Helpers/WorkUtils.cc",
-	"Helpers/TimeProvider.cc",
-	
-	#model and provider
-	"Model/ObjectsOwner.cc",
-	"Model/StoredObject.cc",
-	"Model/Assignment.cc",
-	"Model/ConstantsTypeColumn.cc",
-	"Model/ConstantsTypeTable.cc",
-	"Model/Directory.cc",
-	"Model/EventRange.cc",
-	"Model/RunRange.cc",
-	"Model/Variation.cc",
-	"Providers/DataProvider.cc",
-	"Providers/FileDataProvider.cc",
+
+    #helper classes
+    "Helpers/StringUtils.cc",
+    "Helpers/PathUtils.cc",
+    "Helpers/WorkUtils.cc",
+    "Helpers/TimeProvider.cc",
+
+    #model and provider
+    "Model/ObjectsOwner.cc",
+    "Model/StoredObject.cc",
+    "Model/Assignment.cc",
+    "Model/ConstantsTypeColumn.cc",
+    "Model/ConstantsTypeTable.cc",
+    "Model/Directory.cc",
+    "Model/EventRange.cc",
+    "Model/RunRange.cc",
+    "Model/Variation.cc",
+    "Providers/DataProvider.cc",
+    "Providers/FileDataProvider.cc",
     "Providers/SQLiteDataProvider.cc",
-	"Providers/IAuthentication.cc",
-	"Providers/EnvironmentAuthentication.cc",
-	]
+    "Providers/IAuthentication.cc",
+    "Providers/EnvironmentAuthentication.cc",
+    ]
 
 #additional variables
 env.Append(LIBS = ['pthread'])
 env.Append(LIBS = ccdb_sqlite_lib)
 
 if env['PLATFORM'] != 'darwin':
-	env.Append(LIBS = ['rt'])
+    env.Append(LIBS = ['rt'])
 
 env.Append(CCFLAGS='-Wno-unknown-pragmas -g -O2 -std=c++11') #Disable unknown pragmas warnings. CCDB files have '#pragma region' records to structurize files.
 
@@ -73,35 +73,53 @@ else:
 #Build with mysql or no?                                           
 #Read user flag for using mysql dependencies or not
 if ARGUMENTS.get("mysql","no")=="yes" or ARGUMENTS.get("with-mysql","true")=="true":
-	#User wants mysql!
-	print "Building CCDB using MySQL dependencies"
-	print "To build CCDB without mysql dependencies. Run scons with 'with-mysql=false'"
-	print ""
-	
-	if not WhereIs("mysql_config"):
-		print
-		print 	"ERROR. Can't find 'mysql_config' utility which is needed to build CCDB with MySQL support."
-		print 	"Two options is possible to build CCDB:"
-		print   "  1. Install mysql_config (RHEL has it in mysql-devel package, Ubuntu in libmysqlclient-dev)"
-		print   "  2. Build CCDB without MySQL dependencies (use 'mysql=no' scons flag)"
-		print
-		Exit()
-	
-	mysql_sources = [
-	#user api
-	"MySQLCalibration.cc",
-	
-	#model and provider
-	"Providers/MySQLConnectionInfo.cc",
-	"Providers/MySQLDataProvider.cc"]
-	
-	lib_sources.extend(mysql_sources)	
-	env.Append(CPPDEFINES='CCDB_MYSQL')
-	env.Append(LIBS='mysqlclient')
-	env.ParseConfig('mysql_config --cflags')
+    #User wants mysql!
+    print "Building CCDB using MySQL dependencies"
+    print "To build CCDB without mysql dependencies. Run scons with 'with-mysql=false'"
+    print ""
+
+    print('WhereIs("mysql_config"): {}'.format(WhereIs("mysql_config")))
+
+    mysql_config_path = WhereIs("mysql_config")
+
+    if not mysql_config_path:
+        print
+        print 	"ERROR. Can't find 'mysql_config' utility which is needed to build CCDB with MySQL support."
+        print 	"Two options is possible to build CCDB:"
+        print   "  1. Install mysql_config (RHEL has it in mysql-devel package, Ubuntu in libmysqlclient-dev)"
+        print   "  2. Build CCDB without MySQL dependencies (use 'mysql=no' scons flag)"
+        print
+        Exit()
+
+    mysql_sources = [
+    #user api
+    "MySQLCalibration.cc",
+
+    #model and provider
+    "Providers/MySQLConnectionInfo.cc",
+    "Providers/MySQLDataProvider.cc"]
+
+    lib_sources.extend(mysql_sources)
+    env.Append(CPPDEFINES='CCDB_MYSQL')
+
+    from subprocess import Popen, PIPE
+    import shlex
+
+    process = Popen([mysql_config_path, "--libs", "--cflags"], stdout=PIPE)
+    (output, err) = process.communicate()
+    exit_code = process.wait()
+
+    mysql_lib_location_flag = ""
+    for token in shlex.split(output):
+        if token.startswith('-L'):
+            env.Append(LINKFLAGS=[token])   # Add something like -L/usr/lib64/mysql to lib flags
+            break
+
+    env.Append(LIBS=['mysqlclient'])
+    env.ParseConfig('mysql_config --cflags')
 else:
-	print "CCDB is being build WITHOUT MySQL support. Use 'with-mysql=true' flag to explicitly enable MySQL support"
-	
+    print "CCDB is being build WITHOUT MySQL support. Use 'with-mysql=true' flag to explicitly enable MySQL support"
+
 
 if ARGUMENTS.get("with-perflog","false")=="true":
     print("with-perflog=true  - compile with performance logging ")


### PR DESCRIPTION
Due to a handful of syntax errors that are invalid in python3, compiling CCDB with scons fails with systems using python3 (should now be the default!). These changes correct this to allow compilation with scons and python3. I have not addressed other python3 related issues, they seemed to be covered in the py3 branch.