### PR TITLE
Make the scons compatible with Python3 (Python2 is deprecated)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3,8 +3,8 @@ import os
 
 #Setup default environment. This environment 
 if not 'CCDB_HOME' in os.environ:
-    print "CCDB_HOME environment variable is not found but should be set to compile the CCDB"
-    print "One can run 'source environment.bash' from your bash shell to automatically set environment variables"
+    print("CCDB_HOME environment variable is not found but should be set to compile the CCDB")
+    print("One can run 'source environment.bash' from your bash shell to automatically set environment variables")
     exit(1)
 
 #Create 'default' environment. Other environments will be a copy of this one

--- a/src/Library/SConscript
+++ b/src/Library/SConscript
@@ -8,8 +8,8 @@ env = default_env.Clone()  #Clone it to add library specified things
 
 #Mac Os X requires install_name flag to be built properly
 if env['PLATFORM'] == 'darwin':
-    print
-    print "Darwin platform is detected. Setting -install_name @rpath/"+'${TARGET.file}'
+    print()
+    print("Darwin platform is detected. Setting -install_name @rpath/"+'${TARGET.file}')
     env.Append(SHLINKFLAGS = ['-install_name', '@rpath/'+'${TARGET.file}'])
     
 
@@ -74,17 +74,17 @@ else:
 #Read user flag for using mysql dependencies or not
 if ARGUMENTS.get("mysql","no")=="yes" or ARGUMENTS.get("with-mysql","true")=="true":
 	#User wants mysql!
-	print "Building CCDB using MySQL dependencies"
-	print "To build CCDB without mysql dependencies. Run scons with 'with-mysql=false'"
-	print ""
+	print("Building CCDB using MySQL dependencies")
+	print("To build CCDB without mysql dependencies. Run scons with 'with-mysql=false'")
+	print("")
 	
 	if not WhereIs("mysql_config"):
-		print
-		print 	"ERROR. Can't find 'mysql_config' utility which is needed to build CCDB with MySQL support."
-		print 	"Two options is possible to build CCDB:"
-		print   "  1. Install mysql_config (RHEL has it in mysql-devel package, Ubuntu in libmysqlclient-dev)"
-		print   "  2. Build CCDB without MySQL dependencies (use 'mysql=no' scons flag)"
-		print
+		print()
+		print("ERROR. Can't find 'mysql_config' utility which is needed to build CCDB with MySQL support.")
+		print("Two options is possible to build CCDB:")
+		print("  1. Install mysql_config (RHEL has it in mysql-devel package, Ubuntu in libmysqlclient-dev)")
+		print("  2. Build CCDB without MySQL dependencies (use 'mysql=no' scons flag)")
+		print()
 		Exit()
 	
 	mysql_sources = [
@@ -99,7 +99,7 @@ if ARGUMENTS.get("mysql","no")=="yes" or ARGUMENTS.get("with-mysql","true")=="tr
 	env.Append(CPPDEFINES='CCDB_MYSQL')
 	env.ParseConfig('mysql_config --libs --cflags')
 else:
-	print "CCDB is being build WITHOUT MySQL support. Use 'with-mysql=true' flag to explicitly enable MySQL support"
+	print("CCDB is being build WITHOUT MySQL support. Use 'with-mysql=true' flag to explicitly enable MySQL support")
 	
 
 #Making library


### PR DESCRIPTION
The Python2 SConstruct still in 1.07 should be changed so it works with Python3
Pretty minimal changes. 
Could wait with merging this until you have a 1.07.1  also for the CMake modifications.