### PR TITLE
V1 add columns flag to cache key

### DIFF
--- a/src/Library/Calibration.cc
+++ b/src/Library/Calibration.cc
@@ -614,9 +614,9 @@ string Calibration::GetConnectionString() const
 
     // Check if we have this value in the cache
     if (loadColumns) {
-      loadColumnsFlag = "withCols"
+      loadColumnsFlag = "cols";
     } else {
-      loadColumnsFlag = "withoutCols"
+      loadColumnsFlag = "no_cols";
     }
     string cache_key = namepath + ":" + to_string(run) + ":" + variation + ":" + to_string(time) + ":" + loadColumnsFlag;
     if(mIsCacheEnabled)

--- a/src/Library/Calibration.cc
+++ b/src/Library/Calibration.cc
@@ -600,6 +600,7 @@ string Calibration::GetConnectionString() const
 
     RequestParseResult result = PathUtils::ParseRequest(namepath);
     string variation = (result.WasParsedVariation ? result.Variation : mDefaultVariation);
+    string loadColumnsFlag;
     int run  = (result.WasParsedRunNumber ? result.RunNumber : mDefaultRun);
 
 
@@ -612,7 +613,12 @@ string Calibration::GetConnectionString() const
     std::lock_guard<std::mutex> lock(mReadMutex);
 
     // Check if we have this value in the cache
-    string cache_key = namepath + ":" + to_string(run) + ":" + variation + ":" + to_string(time);
+    if (loadColumns) {
+      loadColumnsFlag = "withCols"
+    } else {
+      loadColumnsFlag = "withoutCols"
+    }
+    string cache_key = namepath + ":" + to_string(run) + ":" + variation + ":" + to_string(time) + ":" + loadColumnsFlag;
     if(mIsCacheEnabled)
     {
         if (  cache.find(cache_key) != cache.end() ) {

--- a/src/Tests/test_NoMySqlUserAPI.cc
+++ b/src/Tests/test_NoMySqlUserAPI.cc
@@ -75,6 +75,14 @@ TEST_CASE("CCDB/UserAPI/SQLite","tests")
     vector<string> paths;
     REQUIRE_NOTHROW(calib->GetListOfNamepaths(paths));
     REQUIRE(paths.size()>0);
+
+    //test of getting an assignment
+    //----------------------------------------------------
+    Assignment* assignment;
+    assignment = calib->GetAssignment("/test/test_vars/test_table:1000:default", true);
+    vector<ConstantsTypeColumn *> columns;
+    columns = assignment->GetTypeTable()->GetColumns();
+    REQUIRE(columns.size()==3);
 }
 
 


### PR DESCRIPTION
- Add a "col" / "no_cal" qualifier on key for for assignment cache.
- Add a unit test to check for retrieval of column vector from an assignment.