### PR TITLE
Sort directories query to ensure all parents appear before their subdirectories

### DIFF
--- a/java/src/org.jlab.ccdb/MySqlProvider.kt
+++ b/java/src/org.jlab.ccdb/MySqlProvider.kt
@@ -66,7 +66,7 @@ class MySqlProvider(connectionString: String) : JDBCProvider(connectionString) {
 
         val con: Connection = connection!!
 
-        prsDirectories = con.prepareStatement("SELECT id, parentId, name, created, modified, comment FROM directories");
+        prsDirectories = con.prepareStatement("SELECT id, parentId, name, created, modified, comment FROM directories ORDER BY parentId");
         prsVariationById = con.prepareStatement("SELECT id, parentId, name FROM variations WHERE id = ?")
         prsVariationByName = con.prepareStatement("SELECT id, parentId, name FROM variations WHERE name = ?")
         //ok now we must build our mighty query...


### PR DESCRIPTION
We hit a new issue related to CLAS12's CCDB database containing rows in the `directories` table that appear before their parent directory if left unsorted.  My understanding of SQL is that that's perfectly normal and unavoidable.

However, the [corresponding query](https://github.com/JeffersonLab/ccdb/blob/cd7e36b9e2c02d6d796e41cbbebf8bb08598dc4f/java/src/org.jlab.ccdb/MySqlProvider.kt#L69) in the CCDB Java library isn't sorted, and the result is passed unsorted to [the routine](https://github.com/JeffersonLab/ccdb/blob/cd7e36b9e2c02d6d796e41cbbebf8bb08598dc4f/java/src/org.jlab.ccdb/JDBCProvider.kt#L102-L133) that generates the hierarchical directory structure, which assumes parent directories appear before their daughters.

This causes those subdirectories (and their contents) to be inaccessible via the Java CCDB library.  Well, unless you strip off their parent directory in the request, e.g., what should be accessible as "/dog/cat/llama" is really accessible as "cat/llama", where "cat" appears before "dog" in the unsorted query.

Simply sorting the query addresses that issue, and from what I gather, it's just the right thing to do?

Note, the CCDB website and the `ccdb` python CLI do not appear to be affected similarly, and I didn't try very hard to understand why.  But my quick look at the C++ code suggests it should be affected similarly to Java.  Has GlueX ever seen this issue?


