### PR TITLE
Add support for CCDB_CACHE_ON option in CMakeLists

### DIFF
--- a/cpp/src/CCDB/CMakeLists.txt
+++ b/cpp/src/CCDB/CMakeLists.txt
@@ -30,6 +30,15 @@ add_library(ccdb SHARED
 target_include_directories(ccdb PUBLIC "${PROJECT_SOURCE_DIR}/..")
 set_target_properties(ccdb PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+option(CCDB_CACHE_ON "Enable CCDB cache support" OFF)
+
+if(CCDB_CACHE_ON)
+    message(STATUS "Cache is ENABLED")
+    target_compile_definitions(ccdb PUBLIC CCDB_CACHE_ON)
+else()
+    message(STATUS "Cache is DISABLED")
+endif()
+
 # Add SQLITE3
 find_package (SQLite3 REQUIRED)
 if (SQLite3_FOUND)


### PR DESCRIPTION
This PR adds support for the `CCDB_CACHE_ON` CMake option by properly propagating it to the `ccdb` target via `target_compile_definitions`.

Previously, enabling the `CCDB_CACHE_ON` option at build time did not affect compilation because it wasn't forwarded to the compiler. This update adds the following logic to `src/CCDB/CMakeLists.txt`:

```cmake
option(CCDB_CACHE_ON "Enable CCDB cache support" OFF)

if(CCDB_CACHE_ON)
    message(STATUS "Cache is ENABLED")
    target_compile_definitions(ccdb PUBLIC CCDB_CACHE_ON)
else()
    message(STATUS "Cache is DISABLED")
endif()
```

With this change, caching can be enabled at build time using:

```bash
cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=`pwd` -DCCDB_CACHE_ON=1
```

This ensures the cache logic is correctly compiled when the option is enabled.